### PR TITLE
Fix resilient host-agent price updates

### DIFF
--- a/src/analytics/analytics.service.spec.ts
+++ b/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,94 @@
+import { AnalyticsService } from './analytics.service';
+import { analyticsAssets } from './config/analytics-config';
+
+describe('AnalyticsService', () => {
+  const tvls = new Map([['146', 123]]);
+  const pairs = Object.fromEntries(
+    analyticsAssets.map((asset, index) => [
+      asset.symbol,
+      { priceUsd: String(index + 1), priceChange: index },
+    ]),
+  );
+
+  function createService() {
+    const dexScreenerService = {
+      getPair: jest.fn((_network: string, address: string) => {
+        const asset = analyticsAssets.find((item) => item.address === address);
+        if (!asset) throw new Error('unknown asset');
+        return Promise.resolve(pairs[asset.symbol]);
+      }),
+    };
+    const defiLlamaService = {
+      getChainTvls: jest.fn(() => Promise.resolve(tvls)),
+    };
+    const chainsService = {
+      getViemChainById: jest.fn(),
+    };
+
+    return {
+      service: new AnalyticsService(
+        dexScreenerService as never,
+        defiLlamaService as never,
+        chainsService as never,
+      ),
+      dexScreenerService,
+      defiLlamaService,
+    };
+  }
+
+  it('publishes primary and wrapped symbols after a successful refresh', async () => {
+    const { service } = createService();
+
+    await service.onModuleInit();
+
+    expect(service.getChainTvls()).toEqual({ '146': 123 });
+    expect(service.getPricesList()).toMatchObject({
+      STBL: pairs.STBL,
+      xSTBL: pairs.STBL,
+      BTC: pairs.BTC,
+      WBTC: pairs.BTC,
+      ETH: pairs.ETH,
+      wETH: pairs.ETH,
+      weETH: pairs.ETH,
+    });
+  });
+
+  it('publishes successful prices when one asset request fails', async () => {
+    const { service, dexScreenerService } = createService();
+    dexScreenerService.getPair.mockImplementation(
+      (_network: string, address: string) => {
+        const asset = analyticsAssets.find((item) => item.address === address);
+        if (!asset) throw new Error('unknown asset');
+        if (asset.symbol === 'BTC') throw new Error('temporary failure');
+        return Promise.resolve(pairs[asset.symbol]);
+      },
+    );
+
+    await service.onModuleInit();
+
+    expect(service.getPricesList().STBL).toEqual(pairs.STBL);
+    expect(service.getPricesList().ETH).toEqual(pairs.ETH);
+    expect(service.getPricesList().BTC).toBeUndefined();
+  });
+
+  it('retains the last good value when a later refresh fails', async () => {
+    const { service, dexScreenerService } = createService();
+    await service.onModuleInit();
+
+    dexScreenerService.getPair.mockRejectedValue(new Error('provider down'));
+    await service.updateAnalyticsData();
+
+    expect(service.getPricesList().STBL).toEqual(pairs.STBL);
+    expect(service.getPricesList().BTC).toEqual(pairs.BTC);
+  });
+
+  it('updates prices even when the TVL provider fails', async () => {
+    const { service, defiLlamaService } = createService();
+    defiLlamaService.getChainTvls.mockRejectedValue(new Error('llama down'));
+
+    await service.onModuleInit();
+
+    expect(service.getChainTvls()).toEqual({});
+    expect(service.getPricesList().STBL).toEqual(pairs.STBL);
+  });
+});

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -4,12 +4,15 @@ import { DexscreenerService } from '../chain-data-provider/dexscreener.service';
 import { Analytics } from './types/analytics';
 import { analyticsAssets } from './config/analytics-config';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { ChainsService } from 'src/chains/chains.service';
+import { ChainsService } from '../chains/chains.service';
 import { IHostAgentMemoryV3 } from '@daohost/host';
 
 @Injectable()
 export class AnalyticsService implements OnModuleInit {
-  private analytics: Analytics;
+  private analytics: Analytics = {
+    chainTvls: {},
+    prices: {},
+  };
   private logger = new Logger(AnalyticsService.name);
   constructor(
     private readonly dexScreenerService: DexscreenerService,
@@ -21,7 +24,9 @@ export class AnalyticsService implements OnModuleInit {
     try {
       await this.updateAnalytics();
     } catch (e) {
-      this.logger.warn(`Failed to get analytics data: ${e.message}`);
+      this.logger.warn(
+        `Failed to get analytics data: ${this.getErrorMessage(e)}`,
+      );
       this.analytics = {
         chainTvls: {},
         prices: {},
@@ -34,7 +39,9 @@ export class AnalyticsService implements OnModuleInit {
     try {
       await this.updateAnalytics();
     } catch (e) {
-      this.logger.warn(`Failed to get analytics data: ${e.message}`);
+      this.logger.warn(
+        `Failed to get analytics data: ${this.getErrorMessage(e)}`,
+      );
     }
   }
 
@@ -43,7 +50,10 @@ export class AnalyticsService implements OnModuleInit {
   }
 
   getPricesList(): IHostAgentMemoryV3['data']['prices'] {
-    const allSymbols = analyticsAssets.map((asset) => asset.symbol);
+    const allSymbols = analyticsAssets.flatMap((asset) => [
+      asset.symbol,
+      ...asset.wrappedSymbols,
+    ]);
     return Object.fromEntries(
       Object.entries(this.analytics.prices).filter(([symbol]) => {
         return allSymbols.includes(symbol);
@@ -75,25 +85,53 @@ export class AnalyticsService implements OnModuleInit {
   }
 
   private async updateAnalytics() {
-    const tvlsMap = await this.defiLlamaService.getChainTvls();
-
-    const assetPrices = await Promise.all(
-      analyticsAssets.map(async (asset) => {
+    const [tvlsResult, ...priceResults] = await Promise.allSettled([
+      this.defiLlamaService.getChainTvls(),
+      ...analyticsAssets.map(async (asset) => {
         const pair = await this.dexScreenerService.getPair(
           asset.network,
           asset.address,
         );
 
-        return [asset.symbol, ...asset.wrappedSymbols].map((symbol) => [
-          symbol,
-          pair,
-        ]);
+        return [asset.symbol, ...asset.wrappedSymbols].map(
+          (symbol) => [symbol, pair] as const,
+        );
       }),
-    ).then((res) => res.flat());
+    ]);
+
+    const chainTvls =
+      tvlsResult.status === 'fulfilled'
+        ? Object.fromEntries(tvlsResult.value)
+        : this.analytics.chainTvls;
+
+    if (tvlsResult.status === 'rejected') {
+      this.logger.warn(
+        `Failed to get chain TVLs: ${this.getErrorMessage(tvlsResult.reason)}`,
+      );
+    }
+
+    const updatedPrices = { ...this.analytics.prices };
+    priceResults.forEach((result, index) => {
+      const asset = analyticsAssets[index];
+
+      if (result.status === 'fulfilled') {
+        Object.assign(updatedPrices, Object.fromEntries(result.value));
+        return;
+      }
+
+      this.logger.warn(
+        `Failed to get ${asset.symbol} price from Dexscreener ` +
+          `(${asset.network}/${asset.address}): ${this.getErrorMessage(result.reason)}`,
+      );
+    });
 
     this.analytics = {
-      chainTvls: Object.fromEntries(tvlsMap),
-      prices: Object.fromEntries(assetPrices),
+      chainTvls,
+      prices: updatedPrices,
     };
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 }


### PR DESCRIPTION
## Summary

Fixes the host-agent price aggregation path so `dao.host` continues receiving available market prices when an upstream provider request fails.

## Root cause

The analytics refresh used a single `Promise.all` for DefiLlama and every configured Dexscreener asset. A timeout, rate limit, missing pair, or other transient failure from any one request rejected the complete refresh. During startup, that failure initialized the published price map as empty, leaving the `dao.host` price panel without data.

The response filter also excluded configured wrapped symbols even though their prices had already been derived from the underlying asset.

## Changes

- Initialize analytics state safely before the first provider refresh.
- Use independent settled results for chain TVL and asset-price requests.
- Publish successful asset prices even when another asset request fails.
- Preserve the last known successful values during temporary provider outages.
- Keep price updates independent from DefiLlama availability.
- Include configured wrapped symbols such as `xSTBL`, `WBTC`, `wETH`, and `weETH` in the API response.
- Add asset-specific warning logs containing the network and pair address.
- Add regression tests for successful refreshes, partial failures, complete follow-up outages, DefiLlama failures, and wrapped-symbol publication.

## Impact

The `data.prices` payload consumed by `dao.host` is now resilient to isolated upstream failures. A single unavailable provider or trading pair will no longer remove all otherwise-valid prices from the UI.

## Validation

- `yarn build`
- `yarn test --runInBand` — 5 suites and 17 tests passed
- Focused ESLint checks for the changed implementation and tests
- `git diff --check`
- Verified all configured Dexscreener pairs against the live API
- Verified that the deployed `dao.host` price panel consumes `data.prices`

Closes #89
