### PR TITLE
Hide wrapped price aliases from the API

### DIFF
--- a/src/analytics/analytics.service.spec.ts
+++ b/src/analytics/analytics.service.spec.ts
@@ -36,7 +36,7 @@ describe('AnalyticsService', () => {
     };
   }
 
-  it('publishes primary and wrapped symbols after a successful refresh', async () => {
+  it('publishes primary symbols without wrapped aliases', async () => {
     const { service } = createService();
 
     await service.onModuleInit();
@@ -44,13 +44,18 @@ describe('AnalyticsService', () => {
     expect(service.getChainTvls()).toEqual({ '146': 123 });
     expect(service.getPricesList()).toMatchObject({
       STBL: pairs.STBL,
-      xSTBL: pairs.STBL,
       BTC: pairs.BTC,
-      WBTC: pairs.BTC,
       ETH: pairs.ETH,
-      wETH: pairs.ETH,
-      weETH: pairs.ETH,
     });
+    expect(service.getPricesList()).not.toHaveProperty('xSTBL');
+    expect(service.getPricesList()).not.toHaveProperty('WBTC');
+    expect(service.getPricesList()).not.toHaveProperty('wETH');
+    expect(service.getPricesList()).not.toHaveProperty('weETH');
+
+    expect(service.getPriceBySymbol('xSTBL')).toBe(+pairs.STBL.priceUsd);
+    expect(service.getPriceBySymbol('WBTC')).toBe(+pairs.BTC.priceUsd);
+    expect(service.getPriceBySymbol('wETH')).toBe(+pairs.ETH.priceUsd);
+    expect(service.getPriceBySymbol('weETH')).toBe(+pairs.ETH.priceUsd);
   });
 
   it('publishes successful prices when one asset request fails', async () => {

--- a/src/analytics/analytics.service.ts
+++ b/src/analytics/analytics.service.ts
@@ -50,13 +50,10 @@ export class AnalyticsService implements OnModuleInit {
   }
 
   getPricesList(): IHostAgentMemoryV3['data']['prices'] {
-    const allSymbols = analyticsAssets.flatMap((asset) => [
-      asset.symbol,
-      ...asset.wrappedSymbols,
-    ]);
+    const publicSymbols = analyticsAssets.map((asset) => asset.symbol);
     return Object.fromEntries(
       Object.entries(this.analytics.prices).filter(([symbol]) => {
-        return allSymbols.includes(symbol);
+        return publicSymbols.includes(symbol);
       }),
     );
   }


### PR DESCRIPTION
## What changed

- Restrict the public `data.prices` response to primary analytics symbols.
- Remove `xSTBL`, `WBTC`, `wETH`, and `weETH` from the API response.
- Keep wrapped aliases available internally for DAO price calculations.
- Update analytics tests to verify both public filtering and internal alias lookup.

## Why

Wrapped price aliases should not be exposed by the host-agent memory API. They were previously included because `getPricesList()` allowed both primary symbols and every configured wrapped alias.

## Impact

`GET /api/host-agent-memory` and `GET /api/host-agent-memory-v3` no longer include the four wrapped aliases under `data.prices`. Primary `STBL`, `BTC`, and `ETH` prices remain unchanged.

## Validation

- `yarn.cmd test analytics.service.spec.ts --runInBand --forceExit`
- `yarn.cmd build`
- `git diff --check`