### PR TITLE
Add seedMEVBOTS Merkl APR to host memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@daohost/host": "^0.21.0",
+    "@daohost/host": "0.21.1",
+    "@merkl/api": "1.20.21",
     "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.1.6",
     "@nestjs/config": "^4.0.2",

--- a/src/memory/memory.controller.spec.ts
+++ b/src/memory/memory.controller.spec.ts
@@ -1,0 +1,119 @@
+jest.mock('../merkl/merkl.service', () => ({
+  MerklService: class MerklService {},
+}));
+jest.mock('src/analytics/analytics.service', () => ({
+  AnalyticsService: class AnalyticsService {},
+}));
+jest.mock('src/github/github.service', () => ({
+  GithubService: class GithubService {},
+}));
+jest.mock('src/on-chain-data/on-chain-data.service', () => ({
+  OnChainDataService: class OnChainDataService {},
+}));
+jest.mock('src/revenue/revenue.service', () => ({
+  RevenueService: class RevenueService {},
+}));
+jest.mock('src/telegram/telegram.service', () => ({
+  TelegramService: class TelegramService {},
+}));
+jest.mock('src/token-holders/token-holders.service', () => ({
+  TokenHoldersService: class TokenHoldersService {},
+}));
+jest.mock('src/twitter/twitter.service', () => ({
+  TwitterService: class TwitterService {},
+}));
+jest.mock('src/tx-sender/tx-monitoring.service', () => ({
+  TxMonitoringService: class TxMonitoringService {},
+}));
+
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { IHostAgentMemoryV3 } from '@daohost/host';
+import { Server } from 'http';
+import * as request from 'supertest';
+import { AnalyticsService } from 'src/analytics/analytics.service';
+import { GithubService } from 'src/github/github.service';
+import { MerklService } from '../merkl/merkl.service';
+import { OnChainDataService } from 'src/on-chain-data/on-chain-data.service';
+import { RevenueService } from 'src/revenue/revenue.service';
+import { TelegramService } from 'src/telegram/telegram.service';
+import { TokenHoldersService } from 'src/token-holders/token-holders.service';
+import { TwitterService } from 'src/twitter/twitter.service';
+import { TxMonitoringService } from 'src/tx-sender/tx-monitoring.service';
+import { MemoryController } from './memory.controller';
+import { MemoryV2Service } from './memory.service';
+
+describe('MemoryController Merkl integration', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [MemoryController],
+      providers: [
+        MemoryV2Service,
+        { provide: GithubService, useValue: { builderMemory: {} } },
+        {
+          provide: AnalyticsService,
+          useValue: { getChainTvls: () => ({}), getPricesList: () => ({}) },
+        },
+        {
+          provide: RevenueService,
+          useValue: {
+            getRevenueChart: () => ({}),
+            getRevenueChartV2: () => ({}),
+          },
+        },
+        {
+          provide: OnChainDataService,
+          useValue: { getOnChainData: () => ({}) },
+        },
+        {
+          provide: TxMonitoringService,
+          useValue: { spendingReport: undefined },
+        },
+        { provide: TelegramService, useValue: { daoUsers: {} } },
+        { provide: TwitterService, useValue: { twitterFollowers: {} } },
+        {
+          provide: TokenHoldersService,
+          useValue: { getDaoTokenHolder: () => ({}) },
+        },
+        {
+          provide: MerklService,
+          useValue: {
+            getDaoMerklData: (symbol: string) =>
+              symbol === 'MEVBOTS'
+                ? {
+                    '1': {
+                      '1': {
+                        apr: 596.1648072800859,
+                        campaignId: '2316894702041849715',
+                        rewards: [],
+                      },
+                    },
+                  }
+                : undefined,
+          },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('exposes seedMEVBOTS Merkl data through the v3 memory endpoint', async () => {
+    const response = await request(app.getHttpServer() as Server)
+      .get('/host-agent-memory-v3')
+      .expect(200);
+    const body = response.body as IHostAgentMemoryV3;
+
+    expect(body.data.daos.MEVBOTS.merkl?.['1']['1']).toMatchObject({
+      apr: 596.1648072800859,
+      campaignId: '2316894702041849715',
+    });
+  });
+});

--- a/src/memory/memory.module.ts
+++ b/src/memory/memory.module.ts
@@ -9,6 +9,7 @@ import { TxSenderModule } from 'src/tx-sender/tx-sender.module';
 import { TelegramModule } from 'src/telegram/telegram.module';
 import { TwitterModule } from 'src/twitter/twitter.module';
 import { TokenHoldersModule } from 'src/token-holders/token-holders.module';
+import { MerklModule } from 'src/merkl/merkl.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { TokenHoldersModule } from 'src/token-holders/token-holders.module';
     TelegramModule.forRoot(),
     TwitterModule,
     TokenHoldersModule,
+    MerklModule,
   ],
   providers: [MemoryV2Service],
   controllers: [MemoryController],

--- a/src/memory/memory.service.ts
+++ b/src/memory/memory.service.ts
@@ -11,6 +11,7 @@ import { getFullDaos } from 'src/utils/getDaos';
 import { now } from 'src/utils/now';
 import { TokenHoldersService } from '../token-holders/token-holders.service';
 import { IBuildersMemoryV3 } from '@daohost/host/out/api';
+import { MerklService } from 'src/merkl/merkl.service';
 
 @Injectable()
 export class MemoryV2Service {
@@ -26,6 +27,7 @@ export class MemoryV2Service {
     private readonly telegramService: TelegramService,
     private readonly twitterService: TwitterService,
     private readonly tokenHoldersService: TokenHoldersService,
+    private readonly merklService: MerklService,
   ) {
     this.daos = getFullDaos();
   }
@@ -64,10 +66,12 @@ export class MemoryV2Service {
       const twitterFollowers =
         this.twitterService.twitterFollowers[dao.symbol] ?? {};
       const holders = this.tokenHoldersService.getDaoTokenHolder(dao.symbol);
+      const merkl = this.merklService.getDaoMerklData(dao.symbol);
       result[dao.symbol] = {
         oraclePrice: '0',
         coingeckoPrice: '0',
         holders,
+        merkl,
         socialUsers: {
           ...tgUsers,
           ...twitterFollowers,

--- a/src/merkl/merkl.fixture.ts
+++ b/src/merkl/merkl.fixture.ts
@@ -1,0 +1,20 @@
+export const opportunity = {
+  chainId: 1,
+  status: 'LIVE',
+  name: 'Hold MEV Machines SEED',
+  apr: 590,
+  totalApr: 596.1648072800859,
+  latestCampaignEnd: '1787443200',
+  rewardsRecord: {
+    breakdowns: [
+      {
+        campaignId: '2316894702041849715',
+        token: {
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+        },
+      },
+    ],
+  },
+};

--- a/src/merkl/merkl.mapper.spec.ts
+++ b/src/merkl/merkl.mapper.spec.ts
@@ -1,0 +1,99 @@
+import { ContractIndices } from '@daohost/host/out/host.types';
+import { mapSeedMevBotsOpportunity } from './merkl.mapper';
+import { opportunity } from './merkl.fixture';
+
+describe('mapSeedMevBotsOpportunity', () => {
+  it('maps the displayed APR and campaign into the seed contract index', () => {
+    const result = mapSeedMevBotsOpportunity(opportunity);
+
+    expect(result['1'][String(ContractIndices.SEED_TOKEN_1)]).toEqual({
+      apr: 596.1648072800859,
+      campaignId: '2316894702041849715',
+      rewards: [
+        {
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+        },
+      ],
+      name: 'Hold MEV Machines SEED',
+      endDate: '2026-08-23T00:00:00.000Z',
+    });
+  });
+
+  it('falls back to APR and token symbol when optional values are absent', () => {
+    const result = mapSeedMevBotsOpportunity({
+      ...opportunity,
+      totalApr: undefined,
+      latestCampaignEnd: undefined,
+      rewardsRecord: {
+        breakdowns: [
+          {
+            ...opportunity.rewardsRecord.breakdowns[0],
+            token: {
+              ...opportunity.rewardsRecord.breakdowns[0].token,
+              name: null,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result['1']['1']).toMatchObject({
+      apr: 590,
+      endDate: undefined,
+      rewards: [{ symbol: 'USDC', name: 'USDC' }],
+    });
+  });
+
+  it('rejects an opportunity without an active campaign', () => {
+    expect(() =>
+      mapSeedMevBotsOpportunity({
+        chainId: 1,
+        status: 'LIVE',
+        name: 'Hold MEV Machines SEED',
+        apr: 0,
+        totalApr: 0,
+      }),
+    ).toThrow('Merkl opportunity has no active campaign');
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+    'rejects invalid APR %s',
+    (apr) => {
+      expect(() =>
+        mapSeedMevBotsOpportunity({
+          ...opportunity,
+          apr,
+          totalApr: undefined,
+        }),
+      ).toThrow('Merkl opportunity has invalid APR');
+    },
+  );
+
+  it.each([
+    [{ ...opportunity, chainId: 10 }, 'unexpected chain'],
+    [{ ...opportunity, status: 'PAST' }, 'is not live'],
+  ])('rejects an invalid fixed opportunity', (value, message) => {
+    expect(() => mapSeedMevBotsOpportunity(value)).toThrow(message);
+  });
+
+  it('omits malformed reward-token addresses', () => {
+    const result = mapSeedMevBotsOpportunity({
+      ...opportunity,
+      rewardsRecord: {
+        breakdowns: [
+          {
+            ...opportunity.rewardsRecord.breakdowns[0],
+            token: {
+              ...opportunity.rewardsRecord.breakdowns[0].token,
+              address: 'invalid',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result['1']['1'].rewards).toEqual([]);
+  });
+});

--- a/src/merkl/merkl.mapper.ts
+++ b/src/merkl/merkl.mapper.ts
@@ -1,0 +1,68 @@
+import { IDAOAPIDataV2 } from '@daohost/host/out/api';
+import { ContractIndices } from '@daohost/host/out/host.types';
+
+type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
+
+export interface MerklOpportunity {
+  chainId: number;
+  name: string;
+  apr: number;
+  totalApr?: number;
+  latestCampaignEnd?: string | bigint;
+  rewardsRecord?: {
+    breakdowns: {
+      campaignId: string;
+      token: {
+        address: string;
+        symbol: string;
+        name: string | null;
+      };
+    }[];
+  };
+}
+
+export function mapSeedMevBotsOpportunity(
+  opportunity: MerklOpportunity,
+): MerklData {
+  const campaignId = opportunity.rewardsRecord?.breakdowns[0]?.campaignId;
+  const apr = opportunity.totalApr ?? opportunity.apr;
+
+  if (!campaignId) {
+    throw new Error('Merkl opportunity has no active campaign');
+  }
+  if (!Number.isFinite(apr) || apr < 0) {
+    throw new Error(`Merkl opportunity has invalid APR: ${apr}`);
+  }
+
+  const rewards = Array.from(
+    new Map(
+      (opportunity.rewardsRecord?.breakdowns ?? [])
+        .filter((reward) => /^0x[0-9a-fA-F]{40}$/.test(reward.token.address))
+        .map((reward) => [
+          reward.token.address.toLowerCase(),
+          {
+            address: reward.token.address as `0x${string}`,
+            symbol: reward.token.symbol,
+            name: reward.token.name ?? reward.token.symbol,
+          },
+        ]),
+    ).values(),
+  );
+
+  const endTimestamp = Number(opportunity.latestCampaignEnd);
+  const endDate = Number.isFinite(endTimestamp)
+    ? new Date(endTimestamp * 1000).toISOString()
+    : undefined;
+
+  return {
+    [String(opportunity.chainId)]: {
+      [String(ContractIndices.SEED_TOKEN_1)]: {
+        apr,
+        campaignId,
+        rewards,
+        name: opportunity.name,
+        endDate,
+      },
+    },
+  };
+}

--- a/src/merkl/merkl.mapper.ts
+++ b/src/merkl/merkl.mapper.ts
@@ -5,6 +5,7 @@ type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
 
 export interface MerklOpportunity {
   chainId: number;
+  status: string;
   name: string;
   apr: number;
   totalApr?: number;
@@ -27,6 +28,16 @@ export function mapSeedMevBotsOpportunity(
   const campaignId = opportunity.rewardsRecord?.breakdowns[0]?.campaignId;
   const apr = opportunity.totalApr ?? opportunity.apr;
 
+  if (opportunity.chainId !== 1) {
+    throw new Error(
+      `seedMEVBOTS Merkl opportunity has unexpected chain: ${opportunity.chainId}`,
+    );
+  }
+  if (opportunity.status !== 'LIVE') {
+    throw new Error(
+      `seedMEVBOTS Merkl opportunity is not live: ${opportunity.status}`,
+    );
+  }
   if (!campaignId) {
     throw new Error('Merkl opportunity has no active campaign');
   }

--- a/src/merkl/merkl.module.ts
+++ b/src/merkl/merkl.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { MerklService } from './merkl.service';
+
+@Module({
+  providers: [MerklService],
+  exports: [MerklService],
+})
+export class MerklModule {}

--- a/src/merkl/merkl.service.spec.ts
+++ b/src/merkl/merkl.service.spec.ts
@@ -1,51 +1,56 @@
-import { ContractIndices } from '@daohost/host/out/host.types';
-import { mapSeedMevBotsOpportunity } from './merkl.mapper';
+jest.mock('@merkl/api', () => ({ MerklApi: jest.fn() }));
 
-describe('mapSeedMevBotsOpportunity', () => {
-  it('maps the displayed APR and campaign into the seed token entry', () => {
-    const result = mapSeedMevBotsOpportunity({
-      chainId: 1,
-      name: 'Hold MEV Machines SEED',
-      apr: 590,
-      totalApr: 596.1648072800859,
-      latestCampaignEnd: '1787443200',
-      rewardsRecord: {
-        breakdowns: [
-          {
-            campaignId: '2316894702041849715',
-            token: {
-              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-              symbol: 'USDC',
-              name: 'USD Coin',
-            },
-          },
-        ],
-      },
-    });
+import { MerklApi } from '@merkl/api';
+import { MerklService } from './merkl.service';
+import { opportunity } from './merkl.fixture';
 
-    expect(result['1'][String(ContractIndices.SEED_TOKEN_1)]).toEqual({
-      apr: 596.1648072800859,
-      campaignId: '2316894702041849715',
-      rewards: [
-        {
-          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-          symbol: 'USDC',
-          name: 'USD Coin',
-        },
-      ],
-      name: 'Hold MEV Machines SEED',
-      endDate: '2026-08-23T00:00:00.000Z',
-    });
+describe('MerklService', () => {
+  const get = jest.fn();
+  const opportunities = jest.fn(() => ({ get }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (MerklApi as jest.Mock).mockReturnValue({ v4: { opportunities } });
   });
 
-  it('rejects an opportunity without an active campaign', () => {
-    expect(() =>
-      mapSeedMevBotsOpportunity({
-        chainId: 1,
-        name: 'Hold MEV Machines SEED',
-        apr: 0,
-        totalApr: 0,
-      }),
-    ).toThrow('Merkl opportunity has no active campaign');
+  it('loads seedMEVBOTS data during module initialization', async () => {
+    get.mockResolvedValue({ data: opportunity, error: null, status: 200 });
+    const service = new MerklService();
+
+    await service.onModuleInit();
+
+    expect(opportunities).toHaveBeenCalledWith({
+      id: '9682604972499820963',
+    });
+    expect(service.getDaoMerklData('MEVBOTS')?.['1']['1'].apr).toBe(
+      596.1648072800859,
+    );
+    expect(service.getDaoMerklData('STBL')).toBeUndefined();
+  });
+
+  it('retains the last successful value after an API error response', async () => {
+    get
+      .mockResolvedValueOnce({ data: opportunity, error: null, status: 200 })
+      .mockResolvedValueOnce({ data: null, error: {}, status: 503 });
+    const service = new MerklService();
+
+    await service.updateMerklData();
+    const lastSuccessfulValue = service.getDaoMerklData('MEVBOTS');
+    await service.updateMerklData();
+
+    expect(service.getDaoMerklData('MEVBOTS')).toBe(lastSuccessfulValue);
+  });
+
+  it('retains the last successful value after a network failure', async () => {
+    get
+      .mockResolvedValueOnce({ data: opportunity, error: null, status: 200 })
+      .mockRejectedValueOnce(new Error('network unavailable'));
+    const service = new MerklService();
+
+    await service.updateMerklData();
+    const lastSuccessfulValue = service.getDaoMerklData('MEVBOTS');
+    await service.updateMerklData();
+
+    expect(service.getDaoMerklData('MEVBOTS')).toBe(lastSuccessfulValue);
   });
 });

--- a/src/merkl/merkl.service.spec.ts
+++ b/src/merkl/merkl.service.spec.ts
@@ -1,0 +1,51 @@
+import { ContractIndices } from '@daohost/host/out/host.types';
+import { mapSeedMevBotsOpportunity } from './merkl.mapper';
+
+describe('mapSeedMevBotsOpportunity', () => {
+  it('maps the displayed APR and campaign into the seed token entry', () => {
+    const result = mapSeedMevBotsOpportunity({
+      chainId: 1,
+      name: 'Hold MEV Machines SEED',
+      apr: 590,
+      totalApr: 596.1648072800859,
+      latestCampaignEnd: '1787443200',
+      rewardsRecord: {
+        breakdowns: [
+          {
+            campaignId: '2316894702041849715',
+            token: {
+              address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+              symbol: 'USDC',
+              name: 'USD Coin',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result['1'][String(ContractIndices.SEED_TOKEN_1)]).toEqual({
+      apr: 596.1648072800859,
+      campaignId: '2316894702041849715',
+      rewards: [
+        {
+          address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          symbol: 'USDC',
+          name: 'USD Coin',
+        },
+      ],
+      name: 'Hold MEV Machines SEED',
+      endDate: '2026-08-23T00:00:00.000Z',
+    });
+  });
+
+  it('rejects an opportunity without an active campaign', () => {
+    expect(() =>
+      mapSeedMevBotsOpportunity({
+        chainId: 1,
+        name: 'Hold MEV Machines SEED',
+        apr: 0,
+        totalApr: 0,
+      }),
+    ).toThrow('Merkl opportunity has no active campaign');
+  });
+});

--- a/src/merkl/merkl.service.ts
+++ b/src/merkl/merkl.service.ts
@@ -1,0 +1,51 @@
+import { IDAOAPIDataV2 } from '@daohost/host/out/api';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { MerklApi } from '@merkl/api';
+import { mapSeedMevBotsOpportunity } from './merkl.mapper';
+
+const MERKL_API_URL = 'https://api.merkl.xyz';
+const MEVBOTS_DAO_SYMBOL = 'MEVBOTS';
+const SEED_MEVBOTS_OPPORTUNITY_ID = '9682604972499820963';
+
+type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
+
+@Injectable()
+export class MerklService implements OnModuleInit {
+  private readonly logger = new Logger(MerklService.name);
+  private readonly api = MerklApi(MERKL_API_URL).v4;
+  private merklByDao: Record<string, MerklData> = {};
+
+  async onModuleInit() {
+    await this.updateMerklData();
+  }
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async updateMerklData() {
+    try {
+      const response = await this.api
+        .opportunities({ id: SEED_MEVBOTS_OPPORTUNITY_ID })
+        .get({ query: {} });
+
+      if (response.error || !response.data) {
+        throw new Error(`Merkl API returned status ${response.status}`);
+      }
+
+      this.merklByDao[MEVBOTS_DAO_SYMBOL] = mapSeedMevBotsOpportunity(
+        response.data,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to update seedMEVBOTS APR: ${this.getErrorMessage(error)}`,
+      );
+    }
+  }
+
+  getDaoMerklData(daoSymbol: string): MerklData | undefined {
+    return this.merklByDao[daoSymbol];
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,10 +350,15 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@daohost/host@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@daohost/host/-/host-0.21.0.tgz#b69e2cf542c365349e1dd9668bac8b1cedef5970"
-  integrity sha512-wU0lrK0tmPmW2J0yUM1kPfsygIXtY7pBf4p4igmmN4CADr6eLGyojAZBv6rEh11soEObDM3p7as7sI7Fx2ymdQ==
+"@daohost/host@0.21.1":
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@daohost/host/-/host-0.21.1.tgz#b886728e6e6d3547ab0d91274d8adf2e00b1dcb8"
+  integrity sha512-a5fZvE5dgfvZvHCZvWWS6wm7ZcT70n5d1q4Jsb+bfad/74TRcAc8fAKnFfXf1JXy8d3xWHcA/K7rjsv5satiFA==
+
+"@elysiajs/eden@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@elysiajs/eden/-/eden-1.4.0.tgz#d547f7f212c21b2f07bdee5f85abe39275d0d36e"
+  integrity sha512-Elubsibe0mGK1TLsCrG+fXHorxVfS/YvWP/uDv/8bniideMgREH3yp4Hua5zQkejM3HG9nv2EfajsJ/wfqszuA==
 
 "@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
   version "4.9.0"
@@ -881,6 +886,14 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
   integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
+"@merkl/api@1.20.21":
+  version "1.20.21"
+  resolved "https://registry.yarnpkg.com/@merkl/api/-/api-1.20.21.tgz#fa199927cf5309d3f1044f878e2eb9f4edd363cc"
+  integrity sha512-+1h3bpQhl0s6UESNHzWZUmolrqlOJ/xcixQx6yNyKb/cd7K8yOjNDVj6Vh7IXaVgL8pTdYA5rzyGOX13h/UHow==
+  dependencies:
+    "@elysiajs/eden" "1.4.0"
+    elysia "1.4.19"
 
 "@napi-rs/nice-android-arm-eabi@1.1.1":
   version "1.1.1"
@@ -2884,6 +2897,11 @@ cookie@^0.7.1, cookie@~0.7.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
+cookie@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
+
 cookiejar@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
@@ -3084,6 +3102,16 @@ electron-to-chromium@^1.5.249:
   version "1.5.262"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz#c31eed591c6628908451c9ca0f0758ed514aa003"
   integrity sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==
+
+elysia@1.4.19:
+  version "1.4.19"
+  resolved "https://registry.yarnpkg.com/elysia/-/elysia-1.4.19.tgz#570d58aed3fd664abc92f5c8b8b6df835db1f820"
+  integrity sha512-DZb9y8FnWyX5IuqY44SvqAV0DjJ15NeCWHrLdgXrKgTPDPsl3VNwWHqrEr9bmnOCpg1vh6QUvAX/tcxNj88jLA==
+  dependencies:
+    cookie "^1.1.1"
+    exact-mirror "0.2.5"
+    fast-decode-uri-component "^1.0.1"
+    memoirist "^0.4.0"
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -3344,6 +3372,11 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
+exact-mirror@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/exact-mirror/-/exact-mirror-0.2.5.tgz#037c817c875836d7ef98dd1675515c053ff37edb"
+  integrity sha512-u8Wu2lO8nio5lKSJubOydsdNtQmH8ENba5m0nbQYmTvsjksXKYIS1nSShdDlO8Uem+kbo+N6eD5I03cpZ+QsRQ==
+
 execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -3432,6 +3465,11 @@ fast-content-type-parse@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz#5590b6c807cc598be125e6740a9fde589d2b7afb"
   integrity sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==
+
+fast-decode-uri-component@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -4692,6 +4730,11 @@ memfs@^3.4.1:
   integrity sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ==
   dependencies:
     fs-monkey "^1.0.4"
+
+memoirist@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/memoirist/-/memoirist-0.4.0.tgz#7677aa70f8c2f7f0791f8af1b689495c8dbc906d"
+  integrity sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg==
 
 merge-descriptors@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## What changed

- upgrade `@daohost/host` to 0.21.1 and add the official `@merkl/api` package
- fetch the seedMEVBOTS opportunity on startup and every ten minutes
- expose its live aggregate APR, campaign, reward token, name, and end date through `data.daos.MEVBOTS.merkl["1"]["1"]`
- retain the last successful value when Merkl returns an error or the network request fails
- validate that the fixed opportunity is live, remains on Ethereum, contains an active campaign, and reports a finite non-negative APR
- cover response mapping, malformed data, SDK failures, stale-value retention, and the real `/host-agent-memory-v3` HTTP route

## Why

Host Agent did not populate the `merkl` field introduced in `IHostAgentMemoryV3` 0.21.1, so consumers could not display the Merkl APR offered to seedMEVBOTS holders.

The nested key `"1"` is the DAO Host contract index `ContractIndices.SEED_TOKEN_1`, matching the upstream `IDAODeployments` model. It is not Merkl's internal database token ID.

## Impact

API consumers can now read the authoritative live seedMEVBOTS Merkl APR from Ethereum chain ID `1` and seed-token contract index `1`. The APR is supplied as a percentage by Merkl and is not rescaled locally. This PR does not add the future Merkl claim endpoint.

## Validation

- `yarn build`
- `yarn test --runInBand --forceExit` — 8 suites and 30 tests passed
- issue-specific ESLint — passed
- live compiled-service request against opportunity `9682604972499820963`
- upstream Host schema and every published host-ui branch checked for `tokenId` semantics

Closes #92
