### PR TITLE
Generalize Merkl seed-token discovery and address keys

### DIFF
--- a/src/memory/memory.controller.spec.ts
+++ b/src/memory/memory.controller.spec.ts
@@ -43,6 +43,8 @@ import { TxMonitoringService } from 'src/tx-sender/tx-monitoring.service';
 import { MemoryController } from './memory.controller';
 import { MemoryV2Service } from './memory.service';
 
+const seedMEVBOTSAddress = '0x999995c72dd0c41241552c9c889a93dc78d99999';
+
 describe('MemoryController Merkl integration', () => {
   let app: INestApplication;
 
@@ -84,7 +86,7 @@ describe('MemoryController Merkl integration', () => {
               symbol === 'MEVBOTS'
                 ? {
                     '1': {
-                      '1': {
+                      [seedMEVBOTSAddress]: {
                         apr: 596.1648072800859,
                         campaignId: '2316894702041849715',
                         rewards: [],
@@ -111,7 +113,9 @@ describe('MemoryController Merkl integration', () => {
       .expect(200);
     const body = response.body as IHostAgentMemoryV3;
 
-    expect(body.data.daos.MEVBOTS.merkl?.['1']['1']).toMatchObject({
+    expect(
+      body.data.daos.MEVBOTS.merkl?.['1'][seedMEVBOTSAddress],
+    ).toMatchObject({
       apr: 596.1648072800859,
       campaignId: '2316894702041849715',
     });

--- a/src/merkl/merkl.fixture.ts
+++ b/src/merkl/merkl.fixture.ts
@@ -1,5 +1,7 @@
 export const opportunity = {
+  identifier: '0x999995C72dd0c41241552C9C889A93Dc78D99999',
   chainId: 1,
+  action: 'HOLD',
   status: 'LIVE',
   name: 'Hold MEV Machines SEED',
   apr: 590,

--- a/src/merkl/merkl.mapper.spec.ts
+++ b/src/merkl/merkl.mapper.spec.ts
@@ -1,12 +1,13 @@
-import { ContractIndices } from '@daohost/host/out/host.types';
 import { mapSeedMevBotsOpportunity } from './merkl.mapper';
 import { opportunity } from './merkl.fixture';
 
+const seedMEVBOTSAddress = '0x999995c72dd0c41241552c9c889a93dc78d99999';
+
 describe('mapSeedMevBotsOpportunity', () => {
   it('maps the displayed APR and campaign into the seed contract index', () => {
-    const result = mapSeedMevBotsOpportunity(opportunity);
+    const result = mapSeedMevBotsOpportunity(opportunity, seedMEVBOTSAddress);
 
-    expect(result['1'][String(ContractIndices.SEED_TOKEN_1)]).toEqual({
+    expect(result['1'][seedMEVBOTSAddress]).toEqual({
       apr: 596.1648072800859,
       campaignId: '2316894702041849715',
       rewards: [
@@ -22,24 +23,27 @@ describe('mapSeedMevBotsOpportunity', () => {
   });
 
   it('falls back to APR and token symbol when optional values are absent', () => {
-    const result = mapSeedMevBotsOpportunity({
-      ...opportunity,
-      totalApr: undefined,
-      latestCampaignEnd: undefined,
-      rewardsRecord: {
-        breakdowns: [
-          {
-            ...opportunity.rewardsRecord.breakdowns[0],
-            token: {
-              ...opportunity.rewardsRecord.breakdowns[0].token,
-              name: null,
+    const result = mapSeedMevBotsOpportunity(
+      {
+        ...opportunity,
+        totalApr: undefined,
+        latestCampaignEnd: undefined,
+        rewardsRecord: {
+          breakdowns: [
+            {
+              ...opportunity.rewardsRecord.breakdowns[0],
+              token: {
+                ...opportunity.rewardsRecord.breakdowns[0].token,
+                name: null,
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    });
+      seedMEVBOTSAddress,
+    );
 
-    expect(result['1']['1']).toMatchObject({
+    expect(result['1'][seedMEVBOTSAddress]).toMatchObject({
       apr: 590,
       endDate: undefined,
       rewards: [{ symbol: 'USDC', name: 'USDC' }],
@@ -48,13 +52,16 @@ describe('mapSeedMevBotsOpportunity', () => {
 
   it('rejects an opportunity without an active campaign', () => {
     expect(() =>
-      mapSeedMevBotsOpportunity({
-        chainId: 1,
-        status: 'LIVE',
-        name: 'Hold MEV Machines SEED',
-        apr: 0,
-        totalApr: 0,
-      }),
+      mapSeedMevBotsOpportunity(
+        {
+          chainId: 1,
+          status: 'LIVE',
+          name: 'Hold MEV Machines SEED',
+          apr: 0,
+          totalApr: 0,
+        },
+        seedMEVBOTSAddress,
+      ),
     ).toThrow('Merkl opportunity has no active campaign');
   });
 
@@ -62,11 +69,14 @@ describe('mapSeedMevBotsOpportunity', () => {
     'rejects invalid APR %s',
     (apr) => {
       expect(() =>
-        mapSeedMevBotsOpportunity({
-          ...opportunity,
-          apr,
-          totalApr: undefined,
-        }),
+        mapSeedMevBotsOpportunity(
+          {
+            ...opportunity,
+            apr,
+            totalApr: undefined,
+          },
+          seedMEVBOTSAddress,
+        ),
       ).toThrow('Merkl opportunity has invalid APR');
     },
   );
@@ -75,25 +85,30 @@ describe('mapSeedMevBotsOpportunity', () => {
     [{ ...opportunity, chainId: 10 }, 'unexpected chain'],
     [{ ...opportunity, status: 'PAST' }, 'is not live'],
   ])('rejects an invalid fixed opportunity', (value, message) => {
-    expect(() => mapSeedMevBotsOpportunity(value)).toThrow(message);
+    expect(() => mapSeedMevBotsOpportunity(value, seedMEVBOTSAddress)).toThrow(
+      message,
+    );
   });
 
   it('omits malformed reward-token addresses', () => {
-    const result = mapSeedMevBotsOpportunity({
-      ...opportunity,
-      rewardsRecord: {
-        breakdowns: [
-          {
-            ...opportunity.rewardsRecord.breakdowns[0],
-            token: {
-              ...opportunity.rewardsRecord.breakdowns[0].token,
-              address: 'invalid',
+    const result = mapSeedMevBotsOpportunity(
+      {
+        ...opportunity,
+        rewardsRecord: {
+          breakdowns: [
+            {
+              ...opportunity.rewardsRecord.breakdowns[0],
+              token: {
+                ...opportunity.rewardsRecord.breakdowns[0].token,
+                address: 'invalid',
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    });
+      seedMEVBOTSAddress,
+    );
 
-    expect(result['1']['1'].rewards).toEqual([]);
+    expect(result['1'][seedMEVBOTSAddress].rewards).toEqual([]);
   });
 });

--- a/src/merkl/merkl.mapper.spec.ts
+++ b/src/merkl/merkl.mapper.spec.ts
@@ -1,11 +1,16 @@
-import { mapSeedMevBotsOpportunity } from './merkl.mapper';
+import { mapSeedTokenOpportunity, SeedTokenDeployment } from './merkl.mapper';
 import { opportunity } from './merkl.fixture';
 
 const seedMEVBOTSAddress = '0x999995c72dd0c41241552c9c889a93dc78d99999';
+const deployment = {
+  daoSymbol: 'MEVBOTS',
+  chainId: '1',
+  address: seedMEVBOTSAddress,
+} satisfies SeedTokenDeployment;
 
-describe('mapSeedMevBotsOpportunity', () => {
-  it('maps the displayed APR and campaign into the seed contract index', () => {
-    const result = mapSeedMevBotsOpportunity(opportunity, seedMEVBOTSAddress);
+describe('mapSeedTokenOpportunity', () => {
+  it('maps the displayed APR and campaign under the seed-token address', () => {
+    const result = mapSeedTokenOpportunity(opportunity, deployment);
 
     expect(result['1'][seedMEVBOTSAddress]).toEqual({
       apr: 596.1648072800859,
@@ -23,7 +28,7 @@ describe('mapSeedMevBotsOpportunity', () => {
   });
 
   it('falls back to APR and token symbol when optional values are absent', () => {
-    const result = mapSeedMevBotsOpportunity(
+    const result = mapSeedTokenOpportunity(
       {
         ...opportunity,
         totalApr: undefined,
@@ -40,7 +45,7 @@ describe('mapSeedMevBotsOpportunity', () => {
           ],
         },
       },
-      seedMEVBOTSAddress,
+      deployment,
     );
 
     expect(result['1'][seedMEVBOTSAddress]).toMatchObject({
@@ -52,15 +57,14 @@ describe('mapSeedMevBotsOpportunity', () => {
 
   it('rejects an opportunity without an active campaign', () => {
     expect(() =>
-      mapSeedMevBotsOpportunity(
+      mapSeedTokenOpportunity(
         {
-          chainId: 1,
-          status: 'LIVE',
-          name: 'Hold MEV Machines SEED',
+          ...opportunity,
           apr: 0,
           totalApr: 0,
+          rewardsRecord: undefined,
         },
-        seedMEVBOTSAddress,
+        deployment,
       ),
     ).toThrow('Merkl opportunity has no active campaign');
   });
@@ -69,13 +73,13 @@ describe('mapSeedMevBotsOpportunity', () => {
     'rejects invalid APR %s',
     (apr) => {
       expect(() =>
-        mapSeedMevBotsOpportunity(
+        mapSeedTokenOpportunity(
           {
             ...opportunity,
             apr,
             totalApr: undefined,
           },
-          seedMEVBOTSAddress,
+          deployment,
         ),
       ).toThrow('Merkl opportunity has invalid APR');
     },
@@ -83,15 +87,21 @@ describe('mapSeedMevBotsOpportunity', () => {
 
   it.each([
     [{ ...opportunity, chainId: 10 }, 'unexpected chain'],
+    [
+      {
+        ...opportunity,
+        identifier: '0x0000000000000000000000000000000000000000',
+      },
+      'unexpected identifier',
+    ],
+    [{ ...opportunity, action: 'STAKE' }, 'unexpected action'],
     [{ ...opportunity, status: 'PAST' }, 'is not live'],
-  ])('rejects an invalid fixed opportunity', (value, message) => {
-    expect(() => mapSeedMevBotsOpportunity(value, seedMEVBOTSAddress)).toThrow(
-      message,
-    );
+  ])('rejects a mismatched opportunity', (value, message) => {
+    expect(() => mapSeedTokenOpportunity(value, deployment)).toThrow(message);
   });
 
   it('omits malformed reward-token addresses', () => {
-    const result = mapSeedMevBotsOpportunity(
+    const result = mapSeedTokenOpportunity(
       {
         ...opportunity,
         rewardsRecord: {
@@ -106,7 +116,7 @@ describe('mapSeedMevBotsOpportunity', () => {
           ],
         },
       },
-      seedMEVBOTSAddress,
+      deployment,
     );
 
     expect(result['1'][seedMEVBOTSAddress].rewards).toEqual([]);

--- a/src/merkl/merkl.mapper.ts
+++ b/src/merkl/merkl.mapper.ts
@@ -1,5 +1,4 @@
 import { IDAOAPIDataV2 } from '@daohost/host/out/api';
-import { ContractIndices } from '@daohost/host/out/host.types';
 
 type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
 
@@ -24,6 +23,7 @@ export interface MerklOpportunity {
 
 export function mapSeedMevBotsOpportunity(
   opportunity: MerklOpportunity,
+  seedMEVBOTSAddress: `0x${string}`,
 ): MerklData {
   const campaignId = opportunity.rewardsRecord?.breakdowns[0]?.campaignId;
   const apr = opportunity.totalApr ?? opportunity.apr;
@@ -67,7 +67,7 @@ export function mapSeedMevBotsOpportunity(
 
   return {
     [String(opportunity.chainId)]: {
-      [String(ContractIndices.SEED_TOKEN_1)]: {
+      [seedMEVBOTSAddress]: {
         apr,
         campaignId,
         rewards,

--- a/src/merkl/merkl.mapper.ts
+++ b/src/merkl/merkl.mapper.ts
@@ -3,7 +3,9 @@ import { IDAOAPIDataV2 } from '@daohost/host/out/api';
 type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
 
 export interface MerklOpportunity {
+  identifier: string;
   chainId: number;
+  action: string;
   status: string;
   name: string;
   apr: number;
@@ -21,21 +23,39 @@ export interface MerklOpportunity {
   };
 }
 
-export function mapSeedMevBotsOpportunity(
+export interface SeedTokenDeployment {
+  daoSymbol: string;
+  chainId: string;
+  address: `0x${string}`;
+}
+
+export function mapSeedTokenOpportunity(
   opportunity: MerklOpportunity,
-  seedMEVBOTSAddress: `0x${string}`,
+  deployment: SeedTokenDeployment,
 ): MerklData {
   const campaignId = opportunity.rewardsRecord?.breakdowns[0]?.campaignId;
   const apr = opportunity.totalApr ?? opportunity.apr;
 
-  if (opportunity.chainId !== 1) {
+  if (String(opportunity.chainId) !== deployment.chainId) {
     throw new Error(
-      `seedMEVBOTS Merkl opportunity has unexpected chain: ${opportunity.chainId}`,
+      `${deployment.daoSymbol} seed-token opportunity has unexpected chain: ${opportunity.chainId}`,
+    );
+  }
+  if (
+    opportunity.identifier.toLowerCase() !== deployment.address.toLowerCase()
+  ) {
+    throw new Error(
+      `${deployment.daoSymbol} seed-token opportunity has unexpected identifier: ${opportunity.identifier}`,
+    );
+  }
+  if (opportunity.action !== 'HOLD') {
+    throw new Error(
+      `${deployment.daoSymbol} seed-token opportunity has unexpected action: ${opportunity.action}`,
     );
   }
   if (opportunity.status !== 'LIVE') {
     throw new Error(
-      `seedMEVBOTS Merkl opportunity is not live: ${opportunity.status}`,
+      `${deployment.daoSymbol} seed-token opportunity is not live: ${opportunity.status}`,
     );
   }
   if (!campaignId) {
@@ -66,8 +86,8 @@ export function mapSeedMevBotsOpportunity(
     : undefined;
 
   return {
-    [String(opportunity.chainId)]: {
-      [seedMEVBOTSAddress]: {
+    [deployment.chainId]: {
+      [deployment.address]: {
         apr,
         campaignId,
         rewards,

--- a/src/merkl/merkl.service.spec.ts
+++ b/src/merkl/merkl.service.spec.ts
@@ -4,6 +4,8 @@ import { MerklApi } from '@merkl/api';
 import { MerklService } from './merkl.service';
 import { opportunity } from './merkl.fixture';
 
+const seedMEVBOTSAddress = '0x999995c72dd0c41241552c9c889a93dc78d99999';
+
 describe('MerklService', () => {
   const get = jest.fn();
   const opportunities = jest.fn(() => ({ get }));
@@ -22,9 +24,9 @@ describe('MerklService', () => {
     expect(opportunities).toHaveBeenCalledWith({
       id: '9682604972499820963',
     });
-    expect(service.getDaoMerklData('MEVBOTS')?.['1']['1'].apr).toBe(
-      596.1648072800859,
-    );
+    expect(
+      service.getDaoMerklData('MEVBOTS')?.['1'][seedMEVBOTSAddress].apr,
+    ).toBe(596.1648072800859);
     expect(service.getDaoMerklData('STBL')).toBeUndefined();
   });
 

--- a/src/merkl/merkl.service.spec.ts
+++ b/src/merkl/merkl.service.spec.ts
@@ -1,14 +1,15 @@
 jest.mock('@merkl/api', () => ({ MerklApi: jest.fn() }));
 
 import { MerklApi } from '@merkl/api';
-import { MerklService } from './merkl.service';
+import { ContractIndices } from '@daohost/host/out/host.types';
+import { getSeedTokenDeployments, MerklService } from './merkl.service';
 import { opportunity } from './merkl.fixture';
 
 const seedMEVBOTSAddress = '0x999995c72dd0c41241552c9c889a93dc78d99999';
 
 describe('MerklService', () => {
   const get = jest.fn();
-  const opportunities = jest.fn(() => ({ get }));
+  const opportunities = { get };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -16,13 +17,19 @@ describe('MerklService', () => {
   });
 
   it('loads seedMEVBOTS data during module initialization', async () => {
-    get.mockResolvedValue({ data: opportunity, error: null, status: 200 });
+    get.mockResolvedValue({ data: [opportunity], error: null, status: 200 });
     const service = new MerklService();
 
     await service.onModuleInit();
 
-    expect(opportunities).toHaveBeenCalledWith({
-      id: '9682604972499820963',
+    expect(get).toHaveBeenCalledWith({
+      query: {
+        identifier: seedMEVBOTSAddress,
+        chainId: '1',
+        action: 'HOLD',
+        status: 'LIVE',
+        campaigns: true,
+      },
     });
     expect(
       service.getDaoMerklData('MEVBOTS')?.['1'][seedMEVBOTSAddress].apr,
@@ -32,7 +39,7 @@ describe('MerklService', () => {
 
   it('retains the last successful value after an API error response', async () => {
     get
-      .mockResolvedValueOnce({ data: opportunity, error: null, status: 200 })
+      .mockResolvedValueOnce({ data: [opportunity], error: null, status: 200 })
       .mockResolvedValueOnce({ data: null, error: {}, status: 503 });
     const service = new MerklService();
 
@@ -45,7 +52,7 @@ describe('MerklService', () => {
 
   it('retains the last successful value after a network failure', async () => {
     get
-      .mockResolvedValueOnce({ data: opportunity, error: null, status: 200 })
+      .mockResolvedValueOnce({ data: [opportunity], error: null, status: 200 })
       .mockRejectedValueOnce(new Error('network unavailable'));
     const service = new MerklService();
 
@@ -54,5 +61,29 @@ describe('MerklService', () => {
     await service.updateMerklData();
 
     expect(service.getDaoMerklData('MEVBOTS')).toBe(lastSuccessfulValue);
+  });
+
+  it('discovers seed-token deployments for any DAO and chain', () => {
+    const makeDao = (
+      symbol: string,
+      deployments: Record<string, Record<number, `0x${string}`>>,
+    ) => ({ symbol, deployments }) as never;
+    const firstAddress = '0x1111111111111111111111111111111111111111';
+    const secondAddress = '0x2222222222222222222222222222222222222222';
+
+    expect(
+      getSeedTokenDeployments([
+        makeDao('FIRST', {
+          '1': { [ContractIndices.SEED_TOKEN_1]: firstAddress },
+        }),
+        makeDao('SECOND', {
+          '10': { [ContractIndices.SEED_TOKEN_1]: secondAddress },
+        }),
+        makeDao('NOSEED', { '1': {} }),
+      ]),
+    ).toEqual([
+      { daoSymbol: 'FIRST', chainId: '1', address: firstAddress },
+      { daoSymbol: 'SECOND', chainId: '10', address: secondAddress },
+    ]);
   });
 });

--- a/src/merkl/merkl.service.ts
+++ b/src/merkl/merkl.service.ts
@@ -1,17 +1,30 @@
-import { daos } from '@daohost/host';
+import { daos, IDAOData } from '@daohost/host';
 import { IDAOAPIDataV2 } from '@daohost/host/out/api';
 import { ContractIndices } from '@daohost/host/out/host.types';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { MerklApi } from '@merkl/api';
-import { mapSeedMevBotsOpportunity } from './merkl.mapper';
+import {
+  mapSeedTokenOpportunity,
+  MerklOpportunity,
+  SeedTokenDeployment,
+} from './merkl.mapper';
 
 const MERKL_API_URL = 'https://api.merkl.xyz';
-const MEVBOTS_DAO_SYMBOL = 'MEVBOTS';
-const SEED_MEVBOTS_OPPORTUNITY_ID = '9682604972499820963';
-const ETHEREUM_CHAIN_ID = '1';
 
 type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
+
+export function getSeedTokenDeployments(
+  daoRegistry: IDAOData[] = daos,
+): SeedTokenDeployment[] {
+  return daoRegistry.flatMap((dao) =>
+    Object.entries(dao.deployments).flatMap(([chainId, deployments]) => {
+      const address = deployments?.[ContractIndices.SEED_TOKEN_1];
+
+      return address ? [{ daoSymbol: dao.symbol, chainId, address }] : [];
+    }),
+  );
+}
 
 @Injectable()
 export class MerklService implements OnModuleInit {
@@ -25,22 +38,58 @@ export class MerklService implements OnModuleInit {
 
   @Cron(CronExpression.EVERY_10_MINUTES)
   async updateMerklData() {
+    await Promise.all(
+      getSeedTokenDeployments().map((deployment) =>
+        this.updateSeedToken(deployment),
+      ),
+    );
+  }
+
+  private async updateSeedToken(deployment: SeedTokenDeployment) {
     try {
-      const response = await this.api
-        .opportunities({ id: SEED_MEVBOTS_OPPORTUNITY_ID })
-        .get({ query: {} });
+      const response = await this.api.opportunities.get({
+        query: {
+          identifier: deployment.address,
+          chainId: deployment.chainId,
+          action: 'HOLD',
+          status: 'LIVE',
+          campaigns: true,
+        },
+      });
 
       if (response.error || !response.data) {
         throw new Error(`Merkl API returned status ${response.status}`);
       }
 
-      this.merklByDao[MEVBOTS_DAO_SYMBOL] = mapSeedMevBotsOpportunity(
-        response.data,
-        this.getSeedMEVBOTSAddress(),
+      const opportunity = response.data.find(
+        (item) =>
+          item !== null &&
+          item.identifier.toLowerCase() === deployment.address.toLowerCase() &&
+          String(item.chainId) === deployment.chainId &&
+          item.action === 'HOLD' &&
+          item.status === 'LIVE',
       );
+
+      if (!opportunity) {
+        throw new Error('Merkl API returned no matching live HOLD opportunity');
+      }
+
+      const mapped = mapSeedTokenOpportunity(
+        opportunity as MerklOpportunity,
+        deployment,
+      );
+      const currentDaoData = this.merklByDao[deployment.daoSymbol] ?? {};
+
+      this.merklByDao[deployment.daoSymbol] = {
+        ...currentDaoData,
+        [deployment.chainId]: {
+          ...currentDaoData[deployment.chainId],
+          ...mapped[deployment.chainId],
+        },
+      };
     } catch (error) {
       this.logger.warn(
-        `Failed to update seedMEVBOTS APR: ${this.getErrorMessage(error)}`,
+        `Failed to update ${deployment.daoSymbol} seed-token APR on chain ${deployment.chainId}: ${this.getErrorMessage(error)}`,
       );
     }
   }
@@ -51,16 +100,5 @@ export class MerklService implements OnModuleInit {
 
   private getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
-  }
-
-  private getSeedMEVBOTSAddress(): `0x${string}` {
-    const address = daos.find((dao) => dao.symbol === MEVBOTS_DAO_SYMBOL)
-      ?.deployments[ETHEREUM_CHAIN_ID]?.[ContractIndices.SEED_TOKEN_1];
-
-    if (!address) {
-      throw new Error('seedMEVBOTS deployment address is missing');
-    }
-
-    return address;
   }
 }

--- a/src/merkl/merkl.service.ts
+++ b/src/merkl/merkl.service.ts
@@ -1,4 +1,6 @@
+import { daos } from '@daohost/host';
 import { IDAOAPIDataV2 } from '@daohost/host/out/api';
+import { ContractIndices } from '@daohost/host/out/host.types';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { MerklApi } from '@merkl/api';
@@ -7,6 +9,7 @@ import { mapSeedMevBotsOpportunity } from './merkl.mapper';
 const MERKL_API_URL = 'https://api.merkl.xyz';
 const MEVBOTS_DAO_SYMBOL = 'MEVBOTS';
 const SEED_MEVBOTS_OPPORTUNITY_ID = '9682604972499820963';
+const ETHEREUM_CHAIN_ID = '1';
 
 type MerklData = NonNullable<IDAOAPIDataV2['merkl']>;
 
@@ -33,6 +36,7 @@ export class MerklService implements OnModuleInit {
 
       this.merklByDao[MEVBOTS_DAO_SYMBOL] = mapSeedMevBotsOpportunity(
         response.data,
+        this.getSeedMEVBOTSAddress(),
       );
     } catch (error) {
       this.logger.warn(
@@ -47,5 +51,16 @@ export class MerklService implements OnModuleInit {
 
   private getErrorMessage(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+  }
+
+  private getSeedMEVBOTSAddress(): `0x${string}` {
+    const address = daos.find((dao) => dao.symbol === MEVBOTS_DAO_SYMBOL)
+      ?.deployments[ETHEREUM_CHAIN_ID]?.[ContractIndices.SEED_TOKEN_1];
+
+    if (!address) {
+      throw new Error('seedMEVBOTS deployment address is missing');
+    }
+
+    return address;
   }
 }


### PR DESCRIPTION
## Summary
- discover every DAO seed-token deployment from the `daos` registry in `@daohost/host`
- query Merkl dynamically by seed-token address, chain, `HOLD` action, and `LIVE` status
- key each result as `merkl[chainId][seedTokenAddress]` instead of using the Host contract index as the output key
- fetch APR, campaign ID, rewards, name, and end date from the Merkl API
- validate returned opportunity identity, chain, action, status, campaign, and APR
- retain the last successful value independently when a seed-token update fails

## Dynamic behavior
There are no DAO symbols, chain IDs, token addresses, Merkl opportunity IDs, APRs, campaign IDs, reward metadata, names, or dates hardcoded in production. Adding another DAO seed-token deployment to the Host registry makes it eligible for discovery without changing this service.

## Validation
- live Merkl list query confirmed address-based discovery and campaign breakdowns
- `yarn build`
- full Jest suite: 8 suites, 33 tests passed
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`