### PR TITLE
Complete artifact sorting by income and profit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Host Agent
 
 _Under construction_
+
+## Artifact sorting
+
+Artifact lists can be sorted by mined income or profit. Sorting is applied
+after filtering and before pagination, so every page belongs to the globally
+sorted result set.
+
+```http
+GET /api/artifacts?sort=income&order=desc&page=1&limit=20
+GET /api/artifacts?sort=profit&order=asc&page=1&limit=20
+GET /api/artifacts/by-flight/:flightId?sort=income&order=desc
+```
+
+`sort` accepts `income` or `profit`. `order` accepts `asc` or `desc` and
+defaults to `desc` when sorting is requested. Unsupported values return HTTP 400. Artifacts without a finite value for the selected field are placed last
+in either direction.

--- a/src/artifacts/artifact-filters.spec.ts
+++ b/src/artifacts/artifact-filters.spec.ts
@@ -3,6 +3,7 @@ import {
   matchesLoseReason,
   matchesMiner,
   sortArtifactsByValue,
+  validateArtifactSort,
 } from './artifact-filters';
 
 describe('artifact filters', () => {
@@ -68,5 +69,45 @@ describe('artifact filters', () => {
     expect(
       sortArtifactsByValue(artifacts, 'income', 'desc').map(({ id }) => id),
     ).toEqual(['valued', 'missing']);
+  });
+
+  it('defaults value sorting to descending order', () => {
+    const artifacts = [
+      { id: 'low', value: { income: 1 } },
+      { id: 'high', value: { income: 2 } },
+    ] as never[];
+
+    expect(
+      sortArtifactsByValue(artifacts, 'income').map(({ id }) => id),
+    ).toEqual(['high', 'low']);
+  });
+
+  it('sorts zero and negative values numerically', () => {
+    const artifacts = [
+      { id: 'zero', value: { profit: 0 } },
+      { id: 'positive', value: { profit: 2 } },
+      { id: 'negative', value: { profit: -2 } },
+    ] as never[];
+
+    expect(
+      sortArtifactsByValue(artifacts, 'profit', 'asc').map(({ id }) => id),
+    ).toEqual(['negative', 'zero', 'positive']);
+  });
+
+  it('validates supported sort query values', () => {
+    expect(validateArtifactSort('income', 'asc')).toEqual({
+      sort: 'income',
+      order: 'asc',
+    });
+    expect(validateArtifactSort()).toEqual({
+      sort: undefined,
+      order: undefined,
+    });
+    expect(() => validateArtifactSort('created', 'asc')).toThrow(
+      'sort must be one of: income, profit',
+    );
+    expect(() => validateArtifactSort('income', 'sideways')).toThrow(
+      'order must be one of: asc, desc',
+    );
   });
 });

--- a/src/artifacts/artifact-filters.ts
+++ b/src/artifacts/artifact-filters.ts
@@ -1,4 +1,36 @@
 import type { IMevArtifact } from '@daohost/host';
+import { BadRequestException } from '@nestjs/common';
+
+export const ARTIFACT_SORT_FIELDS = ['income', 'profit'] as const;
+export const ARTIFACT_SORT_ORDERS = ['asc', 'desc'] as const;
+
+export type ArtifactSortField = (typeof ARTIFACT_SORT_FIELDS)[number];
+export type ArtifactSortOrder = (typeof ARTIFACT_SORT_ORDERS)[number];
+
+export function validateArtifactSort(
+  sort?: string,
+  order?: string,
+): {
+  sort?: ArtifactSortField;
+  order?: ArtifactSortOrder;
+} {
+  if (sort && !ARTIFACT_SORT_FIELDS.includes(sort as ArtifactSortField)) {
+    throw new BadRequestException(
+      `sort must be one of: ${ARTIFACT_SORT_FIELDS.join(', ')}`,
+    );
+  }
+
+  if (order && !ARTIFACT_SORT_ORDERS.includes(order as ArtifactSortOrder)) {
+    throw new BadRequestException(
+      `order must be one of: ${ARTIFACT_SORT_ORDERS.join(', ')}`,
+    );
+  }
+
+  return {
+    sort: sort as ArtifactSortField | undefined,
+    order: order as ArtifactSortOrder | undefined,
+  };
+}
 
 function normalize(value: string | undefined): string {
   return value?.trim().toLowerCase() ?? '';
@@ -46,10 +78,10 @@ export function countArtifactsByLoseReason(
 
 export function sortArtifactsByValue<T extends IMevArtifact>(
   artifacts: T[],
-  sort?: string,
-  order?: string,
+  sort?: ArtifactSortField,
+  order?: ArtifactSortOrder,
 ): T[] {
-  if (sort !== 'income' && sort !== 'profit') {
+  if (!sort) {
     return artifacts;
   }
 

--- a/src/artifacts/artifacts.controller.spec.ts
+++ b/src/artifacts/artifacts.controller.spec.ts
@@ -75,4 +75,67 @@ describe('ArtifactsController filters', () => {
     expect(response.data.map(({ id }) => id)).toEqual(['b', 'c']);
     expect(response.total).toBe(3);
   });
+
+  it('sorts artifacts within a flight before pagination', async () => {
+    const artifactsService = {
+      findByIds: jest.fn(() => [
+        artifact('a', 'Unknown', MINER_A, 10, 3),
+        artifact('b', 'Unknown', MINER_A, 30, 1),
+        artifact('c', 'Unknown', MINER_A, 20, 2),
+      ]),
+    };
+    const flightsService = {
+      findById: jest.fn(async () => ({
+        id: 'flight-1',
+        made: ['a', 'b', 'c'],
+      })),
+    };
+    const controller = new ArtifactsController(
+      artifactsService as never,
+      flightsService as never,
+      { findAll: jest.fn(() => []) } as never,
+    );
+
+    const response = await controller.findByFlight(
+      'flight-1',
+      '1',
+      '2',
+      undefined,
+      undefined,
+      'profit',
+      'asc',
+    );
+
+    expect(response.data.map(({ id }) => id)).toEqual(['b', 'c']);
+    expect(response.total).toBe(3);
+  });
+
+  it('rejects unsupported sort fields and orders', async () => {
+    const controller = new ArtifactsController(
+      { findAll: jest.fn(() => []) } as never,
+      { findAll: jest.fn(async () => []) } as never,
+      { findAll: jest.fn(() => []) } as never,
+    );
+
+    await expect(
+      controller.findAll(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'created',
+        'asc',
+      ),
+    ).rejects.toThrow('sort must be one of: income, profit');
+    await expect(
+      controller.findAll(
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'income',
+        'sideways',
+      ),
+    ).rejects.toThrow('order must be one of: asc, desc');
+  });
 });

--- a/src/artifacts/artifacts.controller.ts
+++ b/src/artifacts/artifacts.controller.ts
@@ -22,6 +22,7 @@ import {
   matchesLoseReason,
   matchesMiner,
   sortArtifactsByValue,
+  validateArtifactSort,
 } from './artifact-filters';
 
 @Controller('artifacts')
@@ -116,6 +117,7 @@ export class ArtifactsController {
     @Query('sort') sort?: string,
     @Query('order') order?: string,
   ) {
+    const validatedSort = validateArtifactSort(sort, order);
     const flight = await this.flightsService.findById(flightId);
     if (!flight) {
       throw new NotFoundException(`Flight ${flightId} not found`);
@@ -128,8 +130,8 @@ export class ArtifactsController {
       mined
         .filter((a) => matchesLoseReason(a, loseReason))
         .map((a) => this.enrich(a, flight.id)),
-      sort,
-      order,
+      validatedSort.sort,
+      validatedSort.order,
     );
 
     return this.paginate(all, page, limit, totalsByLoseReason);
@@ -166,6 +168,7 @@ export class ArtifactsController {
     @Query('sort') sort?: string,
     @Query('order') order?: string,
   ) {
+    const validatedSort = validateArtifactSort(sort, order);
     const flightIndex = await this.buildFlightIndex();
     const mined = this.artifactsService
       .findAll()
@@ -175,8 +178,8 @@ export class ArtifactsController {
       mined
         .filter((a) => matchesLoseReason(a, loseReason))
         .map((a) => this.enrich(a, flightIndex.get(a.id))),
-      sort,
-      order,
+      validatedSort.sort,
+      validatedSort.order,
     );
 
     return this.paginate(all, page, limit, totalsByLoseReason);


### PR DESCRIPTION
## Summary

Completes and hardens the backend contract for sorting MEV artifacts by mined income or profit.

- defines the supported `sort` values (`income`, `profit`) and `order` values (`asc`, `desc`)
- validates query parameters for both artifact list endpoints and returns HTTP 400 for unsupported values
- preserves descending order as the default when a sort field is provided
- keeps artifacts without a finite value at the end in either direction
- applies sorting after filters and before pagination so pagination operates on the globally sorted result set
- documents the API contract and examples for the UI integration

## Endpoints

The same sorting contract is supported by both endpoints:

```http
GET /api/artifacts?sort=income&order=desc&page=1&limit=20
GET /api/artifacts?sort=profit&order=asc&page=1&limit=20
GET /api/artifacts/by-flight/:flightId?sort=income&order=desc
```

### Query contract

| Parameter | Accepted values | Behavior |
| --- | --- | --- |
| `sort` | `income`, `profit` | Omitting it preserves the existing artifact order |
| `order` | `asc`, `desc` | Defaults to `desc` when sorting is requested |

Unsupported values return `400 Bad Request` with an actionable error message.

## Test coverage

Added coverage for:

- income and profit sorting in both directions
- default descending order
- zero and negative numeric values
- artifacts with missing/non-finite selected values
- sorting before pagination
- sorting and pagination for `/artifacts/by-flight/:flightId`
- invalid sort fields and sort orders

## Verification

- `yarn test --runInBand` — 8 suites passed, 38 tests passed
- `yarn build` — passed
- `git diff --check` — passed

Closes #88