### PR TITLE
Proxy Merkl user rewards API

### DIFF
--- a/src/merkl/merkl-rewards.service.spec.ts
+++ b/src/merkl/merkl-rewards.service.spec.ts
@@ -1,0 +1,78 @@
+import { HttpService } from '@nestjs/axios';
+import { BadGatewayException } from '@nestjs/common';
+import { AxiosHeaders, AxiosRequestConfig } from 'axios';
+import { of, throwError } from 'rxjs';
+import { MerklRewardsService } from './merkl-rewards.service';
+
+describe('MerklRewardsService', () => {
+  const get = jest.fn();
+  const service = new MerklRewardsService({ get } as unknown as HttpService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards the address, original query string, and authorization', async () => {
+    const data = '[{"rewards":{"amount":"900719925474099312345"}}]';
+    get.mockReturnValue(
+      of({
+        data,
+        status: 200,
+        headers: AxiosHeaders.from({ 'content-type': 'application/json' }),
+      }),
+    );
+
+    await expect(
+      service.getUserRewards(
+        '0xabc/def',
+        'chainId=1&chainId=10&claimableOnly=true',
+        'Bearer secret',
+      ),
+    ).resolves.toEqual({
+      data,
+      status: 200,
+      contentType: 'application/json',
+    });
+
+    expect(get).toHaveBeenCalledWith(
+      'https://api.merkl.xyz/v4/users/0xabc%2Fdef/rewards?chainId=1&chainId=10&claimableOnly=true',
+      expect.objectContaining({
+        headers: {
+          accept: 'application/json',
+          authorization: 'Bearer secret',
+        },
+        responseType: 'text',
+      }),
+    );
+    const call = get.mock.calls[0] as unknown as [string, AxiosRequestConfig];
+    expect(call[1].validateStatus?.(503)).toBe(true);
+  });
+
+  it('preserves an upstream error response', async () => {
+    get.mockReturnValue(
+      of({
+        data: '{"type":"validation"}',
+        status: 422,
+        headers: AxiosHeaders.from({
+          'content-type': 'application/json; charset=utf-8',
+        }),
+      }),
+    );
+
+    await expect(service.getUserRewards('0xabc', 'chainId=1')).resolves.toEqual(
+      {
+        data: '{"type":"validation"}',
+        status: 422,
+        contentType: 'application/json; charset=utf-8',
+      },
+    );
+  });
+
+  it('returns a bad gateway error when Merkl cannot be reached', async () => {
+    get.mockReturnValue(throwError(() => new Error('network unavailable')));
+
+    await expect(
+      service.getUserRewards('0xabc', 'chainId=1'),
+    ).rejects.toBeInstanceOf(BadGatewayException);
+  });
+});

--- a/src/merkl/merkl-rewards.service.ts
+++ b/src/merkl/merkl-rewards.service.ts
@@ -1,0 +1,54 @@
+import { HttpService } from '@nestjs/axios';
+import { BadGatewayException, Injectable } from '@nestjs/common';
+import { AxiosResponse } from 'axios';
+import { firstValueFrom } from 'rxjs';
+
+const MERKL_API_URL = 'https://api.merkl.xyz';
+
+export interface MerklRewardsResponse {
+  data: string;
+  status: number;
+  contentType?: string;
+}
+
+@Injectable()
+export class MerklRewardsService {
+  constructor(private readonly httpService: HttpService) {}
+
+  async getUserRewards(
+    address: string,
+    queryString: string,
+    authorization?: string,
+  ): Promise<MerklRewardsResponse> {
+    const query = queryString ? `?${queryString}` : '';
+    const url = `${MERKL_API_URL}/v4/users/${encodeURIComponent(address)}/rewards${query}`;
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.get<string>(url, {
+          headers: {
+            accept: 'application/json',
+            ...(authorization ? { authorization } : {}),
+          },
+          responseType: 'text',
+          transformResponse: [(data: string) => data],
+          validateStatus: () => true,
+        }),
+      );
+
+      return this.mapResponse(response);
+    } catch {
+      throw new BadGatewayException('Unable to reach Merkl API');
+    }
+  }
+
+  private mapResponse(response: AxiosResponse<string>): MerklRewardsResponse {
+    const contentType = response.headers['content-type'] as unknown;
+
+    return {
+      data: response.data,
+      status: response.status,
+      contentType: typeof contentType === 'string' ? contentType : undefined,
+    };
+  }
+}

--- a/src/merkl/merkl.controller.spec.ts
+++ b/src/merkl/merkl.controller.spec.ts
@@ -1,0 +1,88 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { Server } from 'http';
+import * as request from 'supertest';
+import { MerklRewardsService } from './merkl-rewards.service';
+import { MerklController } from './merkl.controller';
+
+describe('MerklController', () => {
+  let app: INestApplication;
+  const getUserRewards = jest.fn();
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [MerklController],
+      providers: [
+        {
+          provide: MerklRewardsService,
+          useValue: { getUserRewards },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    app.setGlobalPrefix('api');
+    app.enableCors({
+      origin: true,
+      credentials: true,
+      methods: '*',
+      allowedHeaders: '*',
+    });
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('mirrors rewards through the public host API route with CORS', async () => {
+    const body = [
+      {
+        chain: { id: 1 },
+        rewards: [{ amount: '900719925474099312345' }],
+      },
+    ];
+    getUserRewards.mockResolvedValue({
+      data: JSON.stringify(body),
+      status: 200,
+      contentType: 'application/json',
+    });
+
+    const response = await request(app.getHttpServer() as Server)
+      .get(
+        '/api/v4/users/0xabc/rewards?chainId=1&chainId=10&claimableOnly=true',
+      )
+      .set('Origin', 'https://dao.host')
+      .set('Authorization', 'Bearer secret')
+      .expect(200);
+
+    expect(response.body).toEqual(body);
+    expect(response.headers['access-control-allow-origin']).toBe(
+      'https://dao.host',
+    );
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+    expect(getUserRewards).toHaveBeenCalledWith(
+      '0xabc',
+      'chainId=1&chainId=10&claimableOnly=true',
+      'Bearer secret',
+    );
+  });
+
+  it('preserves Merkl error statuses and response bodies', async () => {
+    getUserRewards.mockResolvedValue({
+      data: '{"type":"validation","on":"query"}',
+      status: 422,
+      contentType: 'application/json',
+    });
+
+    const response = await request(app.getHttpServer() as Server)
+      .get('/api/v4/users/0xabc/rewards')
+      .expect(422);
+
+    expect(response.body).toEqual({ type: 'validation', on: 'query' });
+  });
+});

--- a/src/merkl/merkl.controller.ts
+++ b/src/merkl/merkl.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Param, Req, Res } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { MerklRewardsService } from './merkl-rewards.service';
+
+@Controller('v4/users')
+export class MerklController {
+  constructor(private readonly merklRewardsService: MerklRewardsService) {}
+
+  @Get(':address/rewards')
+  async getUserRewards(
+    @Param('address') address: string,
+    @Req() request: Request,
+    @Res() response: Response,
+  ): Promise<void> {
+    const queryStart = request.originalUrl.indexOf('?');
+    const queryString =
+      queryStart === -1 ? '' : request.originalUrl.slice(queryStart + 1);
+    const merklResponse = await this.merklRewardsService.getUserRewards(
+      address,
+      queryString,
+      request.get('authorization'),
+    );
+
+    if (merklResponse.contentType) {
+      response.type(merklResponse.contentType);
+    }
+
+    response.status(merklResponse.status).send(merklResponse.data);
+  }
+}

--- a/src/merkl/merkl.module.ts
+++ b/src/merkl/merkl.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { MerklController } from './merkl.controller';
+import { MerklRewardsService } from './merkl-rewards.service';
 import { MerklService } from './merkl.service';
 
 @Module({
-  providers: [MerklService],
+  imports: [HttpModule],
+  controllers: [MerklController],
+  providers: [MerklService, MerklRewardsService],
   exports: [MerklService],
 })
 export class MerklModule {}


### PR DESCRIPTION
## Summary

- expose `GET /api/v4/users/:address/rewards` as a CORS-enabled mirror of Merkl's user rewards endpoint
- preserve the original query string, upstream response body, status, and content type
- forward optional authorization and return `502 Bad Gateway` for transport failures
- keep user reward requests isolated from the scheduled Merkl opportunity updater

## Testing

- `yarn test --runInBand` (10 suites, 38 tests)
- `yarn test merkl --runInBand` (4 suites, 20 tests)
- targeted ESLint checks
- `yarn build`
- live comparison against Merkl: identical `200` and validation error status/body responses
- verified CORS origin and credentials headers through the compiled local server

Closes #96